### PR TITLE
fix: debian config error

### DIFF
--- a/debian/libdtkcompressor.install
+++ b/debian/libdtkcompressor.install
@@ -1,4 +1,4 @@
-usr/lib/*/libdtkcompressor.so.*
+usr/lib/*/libdtkcompressor.so*
 usr/lib/*/dtkcompressor/plugins/libcli7zplugincompressor.so
 usr/lib/*/dtkcompressor/plugins/libclirarplugincompressor.so
 usr/lib/*/dtkcompressor/plugins/libzipplugincompressor.so

--- a/debian/libdtkio.install
+++ b/debian/libdtkio.install
@@ -1,1 +1,1 @@
-usr/lib/*/libdtkio*.so.*
+usr/lib/*/libdtkio*.so*

--- a/debian/libdtkmount.install
+++ b/debian/libdtkmount.install
@@ -1,1 +1,1 @@
-usr/lib/*/libdtkmount*.so.*
+usr/lib/*/libdtkmount*.so*

--- a/debian/libdtksearch.install
+++ b/debian/libdtksearch.install
@@ -1,1 +1,1 @@
-usr/lib/*/libdtksearch*.so.*
+usr/lib/*/libdtksearch*.so*


### PR DESCRIPTION
Extra "." causes files to be filtered

Log: fix debian config error