### PR TITLE
fix: install error and update version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dtkio (6.0.1) unstable; urgency=medium
+
+  * fix: missing dtk version in CMakeListst.txt
+  * fix: conflict installation files
+
+ -- renbin <renbin@uniontech.com>  Wed, 15 Jan 2025 14:01:07 +0800
+
 dtkio (6.0.0) unstable; urgency=medium
 
   * fix: Update project name to dtk6io in CMakeLists.txt

--- a/debian/libdtk6burn-dev.install
+++ b/debian/libdtk6burn-dev.install
@@ -2,4 +2,3 @@ usr/include/dtk6burn/*
 usr/lib/*/pkgconfig/dtk6burn.pc
 usr/lib/*/cmake/dtk6burn/*.cmake
 usr/lib/*/*/mkspecs/modules/*dtk6burn.pri
-usr/share/*/doc/*.qch

--- a/debian/libdtk6compressor-dev.install
+++ b/debian/libdtk6compressor-dev.install
@@ -2,4 +2,3 @@ usr/include/dtk6compressor/*
 usr/lib/*/pkgconfig/dtk6compressor.pc
 usr/lib/*/cmake/*/dtk6compressor*.cmake
 usr/lib/*/*/mkspecs/modules/*dtk6compressor.pri
-usr/share/*/doc/*.qch

--- a/debian/libdtk6io-dev.install
+++ b/debian/libdtk6io-dev.install
@@ -2,4 +2,4 @@ usr/include/dtk6io/*
 usr/lib/*/pkgconfig/dtk6io.pc
 usr/lib/*/cmake/dtk6io/*.cmake
 usr/lib/*/*/mkspecs/modules/*dtk6io.pri
-usr/share/*/doc/*.qch
+usr/share/*/doc/dtk6io.qch

--- a/debian/libdtk6mount-dev.install
+++ b/debian/libdtk6mount-dev.install
@@ -2,4 +2,3 @@ usr/include/dtk6mount/*
 usr/lib/*/pkgconfig/dtk6mount.pc
 usr/lib/*/cmake/dtk6mount/*.cmake
 usr/lib/*/*/mkspecs/modules/*dtk6mount.pri
-usr/share/*/doc/*.qch

--- a/debian/libdtk6search-dev.install
+++ b/debian/libdtk6search-dev.install
@@ -2,4 +2,3 @@ usr/include/dtk6search/*
 usr/lib/*/pkgconfig/dtk6search.pc
 usr/lib/*/cmake/dtk6search/*.cmake
 usr/lib/*/*/mkspecs/modules/*dtk6search.pri
-usr/share/*/doc/*.qch


### PR DESCRIPTION
[fix: conflict installation files](https://github.com/linuxdeepin/dtkio/commit/69266a0b2b4df28880295ba55178f232e3ef24aa) 

TODO:
The QCH file needs to be split into multiple submodules.

Log: Fix install issue.

[chore: Bump version to 6.0.1](https://github.com/linuxdeepin/dtkio/commit/a0e60649024d65ef2f49c796c9259a14b1938794) 

Bump version to 6.0.1

Log: Bump version to 6.0.1